### PR TITLE
Fix `install-additional-software.sh` to install latest SAMtools

### DIFF
--- a/install-additional-software.sh
+++ b/install-additional-software.sh
@@ -4,7 +4,9 @@ cd bwa
 make
 cd ..
 
-git clone -b master https://github.com/samtools/samtools
-cd samtools
-make
-cd ..
+for sw in htslib bcftools samtools; do                                                                                                                              
+  git clone --branch=develop git://github.com/samtools/${sw}.git                                                                                                    
+  cd ${sw}                                                                                                                                                          
+  make                                                                                                                                                              
+  cd ..                                                                                                                                                             
+done                                                                                                                                                                


### PR DESCRIPTION
The SAMTools code has been split across three separate repos when
migrating to GitHub: `htslib`, `bcftools`, and `samtools`.  In
addition, the code from the SAMTools "master" branch on GitHub does
not compile; instructions say to use the "develop" branch instead.